### PR TITLE
impl boundary check on readMessage function

### DIFF
--- a/pkg/text_reader.go
+++ b/pkg/text_reader.go
@@ -347,7 +347,7 @@ func (r *textReader) readMessage(lineIdx int) (*Message, error) {
 	isExtMux := false
 	extMuxSigs := make(map[string]*Signal)
 
-	for nextLineIdx := lineIdx + 1; true; nextLineIdx++ {
+	for nextLineIdx := lineIdx + 1; nextLineIdx < len(r.lines); nextLineIdx++ {
 		_, ok := applyReg(r.msgEndReg, r.lines[nextLineIdx])
 		if ok {
 			break


### PR DESCRIPTION
Hello,

I was receiving the following error for a DBC of mine:
```sh
panic: runtime error: index out of range [48] with length 48
goroutine 1 [running]:
github.com/squadracorsepolito/jsondbc/pkg.(*textReader).readMessage(0xc000127ae0, 0x2e)
        /home/kelvinc/git/jsondbc/pkg/text_reader.go:351 +0xd91
github.com/squadracorsepolito/jsondbc/pkg.(*textReader).handleMessages(0xc000127ae0?, {0xc0000246c0, 0x6, 0xc000127960?})
...
```

I fixed inserting a validation on the for loop.

Best regards,
Kelvin